### PR TITLE
fix small typo in logo image alt attribute

### DIFF
--- a/application/views/errors/html/error_404.php
+++ b/application/views/errors/html/error_404.php
@@ -70,7 +70,7 @@
     <footer class="footer">
 
       <p class="universityFooter">
-        <img src="/assets/images/elevatorSolo.png" class="elevatorFooterImage" alt="Grain Elevagor Icon">Powered by Elevator, developed by the <A href="http://www.umn.edu">University of Minnesota</a>
+        <img src="/assets/images/elevatorSolo.png" class="elevatorFooterImage" alt="Grain Elevator Icon">Powered by Elevator, developed by the <A href="http://www.umn.edu">University of Minnesota</a>
       </p>
     </footer>
 

--- a/application/views/errors/html/error_exception.php
+++ b/application/views/errors/html/error_exception.php
@@ -94,7 +94,7 @@
     <footer class="footer">
 
       <p class="universityFooter">
-        <img src="/assets/images/elevatorSolo.png" class="elevatorFooterImage" alt="Grain Elevagor Icon">Powered by Elevator, developed by the <A href="http://www.umn.edu">University of Minnesota</a>
+        <img src="/assets/images/elevatorSolo.png" class="elevatorFooterImage" alt="Grain Elevator Icon">Powered by Elevator, developed by the <A href="http://www.umn.edu">University of Minnesota</a>
       </p>
     </footer>
 

--- a/application/views/template.php
+++ b/application/views/template.php
@@ -347,7 +347,7 @@ if(window.location.hash  == "#secondFrame" && inIframe()) {
       <?=file_get_contents("assets/instanceAssets/" . $this->instance->getId() . "_footer.html");?>
       <?endif?>
       <p class="universityFooter">
-        <img src="/assets/images/elevatorSolo.png" class="elevatorFooterImage" alt="Grain Elevagor Icon">Powered by Elevator, developed by the <A href="http://www.umn.edu">University of Minnesota</a>
+        <img src="/assets/images/elevatorSolo.png" class="elevatorFooterImage" alt="Grain Elevator Icon">Powered by Elevator, developed by the <A href="http://www.umn.edu">University of Minnesota</a>
       </p>
     </footer>
 


### PR DESCRIPTION
Changes "Elegator" to "Elevator".

![Elegator](https://media.giphy.com/media/11lfJlKGcgx28g/giphy.gif)


Noticed the typo when googling stuff for AISOS:
<img width="681" alt="Screen Shot 2022-05-10 at 11 05 32 PM" src="https://user-images.githubusercontent.com/980170/167767198-4aaa459e-bbc2-47b1-bd16-64189fb02069.png">

