### PR TITLE
add `userCanSearchAndBrowse` to `getInstanceNav`

### DIFF
--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -136,6 +136,19 @@ class Home extends Instance_Controller {
 		$headerData["pages"] = $outputPages;
 
 		$headerData["userIsloggedIn"] = false;
+
+		$headerData["userCanSearchAndBrowse"] = false;
+		if ($this->user_model) {
+			$accessLevel = $this->user_model->getAccessLevel("instance", $this->instance);
+			if ($accessLevel == PERM_NOPERM) {
+				if (count($this->user_model->getAllowedCollections(PERM_SEARCH)) > 0) {
+					$headerData["userCanSearchAndBrowse"] = true;
+				}
+			} else {
+				$headerData["userCanSearchAndBrowse"] = true;
+			}
+		}
+		
 		$headerData["userCanCreateDrawers"] = false;
 		$headerData["userCanManageAssets"] = false;
 		$headerData["userId"] = null;


### PR DESCRIPTION
Adds prop to indicate whether the current user can search and browse elevator. On the UI side, if this is false – the search bar should not be shown, and the user should see some notification to login.

This is just the logic added to the `feature/homepage-with-new-ui` branch, which was merge into dev already with #123)