### PR TITLE
ElevatorUI error handling

### DIFF
--- a/application/controllers/Asset.php
+++ b/application/controllers/Asset.php
@@ -67,6 +67,10 @@ class asset extends Instance_Controller {
 
 
 	function viewAsset($objectId=null, $returnJson=false) {
+		if ($this->isUsingVueUI() && !$returnJson) {
+			return $this->template->publish('vueTemplate');
+		}
+
 		$assetModel = new Asset_model;
 		if(!$objectId) {
 			show_404();
@@ -90,12 +94,6 @@ class asset extends Instance_Controller {
 			$this->errorhandler_helper->callError("noPermission");
 		}
 		
-
-		if($this->isUsingVueUI() && $returnJson == false) {
-			$this->template->set_template("vueTemplate");
-			$this->template->publish();
-			return;
-		}
 		// Try to find the primary file handler, which might be another asset.  Return the hosting asset, not the filehandler directly
 
 		$targetObject = null;

--- a/application/controllers/Page.php
+++ b/application/controllers/Page.php
@@ -9,6 +9,10 @@ class Page extends Instance_Controller {
 
 	public function view($pageId = null, $returnJSON = false)
 	{
+		if ($this->isUsingVueUI() && !$returnJSON) {
+			return $this->template->publish('vueTemplate');
+		}
+
 		if(!$pageId) {
 			instance_redirect("/");
 		}
@@ -19,12 +23,6 @@ class Page extends Instance_Controller {
 
 		if ($returnJSON) {
 			return render_json(["title" => $page->getTitle(), "content" => $page->getBody()]);
-		}
-
-		if ($this->isUsingVueUI()) {
-			$this->template->set_template("vueTemplate");
-			$this->template->publish();
-			return;
 		}
 
 		$this->template->title = $page->getTitle();

--- a/application/controllers/Search.php
+++ b/application/controllers/Search.php
@@ -18,6 +18,10 @@ class Search extends Instance_Controller {
 
 	public function index($searchId = null)
 	{
+		if ($this->isUsingVueUI()) {
+			return $this->template->publish('vueTemplate');
+		}
+
 		if(!$searchId) {
 			instance_redirect("/");
 		}
@@ -35,13 +39,6 @@ class Search extends Instance_Controller {
 				$this->errorhandler_helper->callError("noPermission");
 			}
 		}
-
-		if ($this->isUsingVueUI()) {
-			$this->template->set_template("vueTemplate");
-			$this->template->publish();
-			return;
-		}
-
 
 		$jsloadArray = array();
 		if(defined('ENVIRONMENT') && ENVIRONMENT == "development") {


### PR DESCRIPTION
This PR goes with UMN-LATIS/elevator-ui#179 which has a bit better error handling in elevator-ui. This moves the check for vueui up so that it can handle errors when the request isn't json.

Previously, the user would be redirected to a legacy error page.