### PR TITLE
Add support for returning `searchID` as json for `querySearch` and `scopedQuerySearch`

### DIFF
--- a/application/controllers/Search.php
+++ b/application/controllers/Search.php
@@ -253,7 +253,9 @@ class Search extends Instance_Controller {
 		$this->doctrine->em->flush();
 		$this->searchId = $searchArchive->getId();
 
-		if ($this->isUsingVueUI()) {
+		$shouldReturnJson = strpos($this->input->get_request_header('Accept', true), 'application/json') !== false;
+
+		if ($this->isUsingVueUI() && $shouldReturnJson) {
 			return $this->output
 			->set_content_type('application/json')
 			->set_output(json_encode(["searchId" => $this->searchId]));
@@ -292,7 +294,9 @@ class Search extends Instance_Controller {
 		$this->doctrine->em->flush();
 		$this->searchId = $searchArchive->getId();
 
-		if ($this->isUsingVueUI()) {
+		$shouldReturnJson = strpos($this->input->get_request_header('Accept', true), 'application/json') !== false;
+
+		if ($this->isUsingVueUI() && $shouldReturnJson) {
 			return $this->output
 			->set_content_type('application/json')
 			->set_output(json_encode(["searchId" => $this->searchId]));

--- a/application/controllers/Search.php
+++ b/application/controllers/Search.php
@@ -252,6 +252,13 @@ class Search extends Instance_Controller {
 		$this->doctrine->em->persist($searchArchive);
 		$this->doctrine->em->flush();
 		$this->searchId = $searchArchive->getId();
+
+		if ($this->isUsingVueUI()) {
+			return $this->output
+			->set_content_type('application/json')
+			->set_output(json_encode(["searchId" => $this->searchId]));
+		}
+
 		instance_redirect("search/s/".$this->searchId);
 	}
 
@@ -284,6 +291,12 @@ class Search extends Instance_Controller {
 		$this->doctrine->em->persist($searchArchive);
 		$this->doctrine->em->flush();
 		$this->searchId = $searchArchive->getId();
+
+		if ($this->isUsingVueUI()) {
+			return $this->output
+			->set_content_type('application/json')
+			->set_output(json_encode(["searchId" => $this->searchId]));
+		}
 
 		instance_redirect("search/s/".$this->searchId);
 	}

--- a/application/controllers/Search.php
+++ b/application/controllers/Search.php
@@ -254,9 +254,7 @@ class Search extends Instance_Controller {
 		$this->searchId = $searchArchive->getId();
 
 		if ($this->isUsingVueUI() && $shouldReturnJson) {
-			return $this->output
-			->set_content_type('application/json')
-			->set_output(json_encode(["searchId" => $this->searchId]));
+			return render_json(["searchId" => $this->searchId]);
 		}
 
 		instance_redirect("search/s/".$this->searchId);
@@ -293,9 +291,7 @@ class Search extends Instance_Controller {
 		$this->searchId = $searchArchive->getId();
 
 		if ($this->isUsingVueUI() && $shouldReturnJson) {
-			return $this->output
-			->set_content_type('application/json')
-			->set_output(json_encode(["searchId" => $this->searchId]));
+			return render_json(["searchId" => $this->searchId]);
 		}
 
 		instance_redirect("search/s/".$this->searchId);

--- a/application/controllers/Search.php
+++ b/application/controllers/Search.php
@@ -235,7 +235,7 @@ class Search extends Instance_Controller {
 		instance_redirect("search/s/".$this->searchId);
 	}
 
-	public function querySearch($searchString = null) {
+	public function querySearch($searchString = null, $shouldReturnJson = false) {
 		if(!$searchString) {
 			instance_redirect("/search");
 		}
@@ -253,7 +253,7 @@ class Search extends Instance_Controller {
 		$this->doctrine->em->flush();
 		$this->searchId = $searchArchive->getId();
 
-		if ($this->isUsingVueUI()) {
+		if ($this->isUsingVueUI() && $shouldReturnJson) {
 			return $this->output
 			->set_content_type('application/json')
 			->set_output(json_encode(["searchId" => $this->searchId]));
@@ -262,7 +262,7 @@ class Search extends Instance_Controller {
 		instance_redirect("search/s/".$this->searchId);
 	}
 
-	public function scopedQuerySearch($fieldName, $searchString = null) {
+	public function scopedQuerySearch($fieldName, $searchString = null, $shouldReturnJson = false) {
 		if(!$searchString) {
 			instance_redirect("/search");
 		}
@@ -292,7 +292,7 @@ class Search extends Instance_Controller {
 		$this->doctrine->em->flush();
 		$this->searchId = $searchArchive->getId();
 
-		if ($this->isUsingVueUI()) {
+		if ($this->isUsingVueUI() && $shouldReturnJson) {
 			return $this->output
 			->set_content_type('application/json')
 			->set_output(json_encode(["searchId" => $this->searchId]));

--- a/application/controllers/Search.php
+++ b/application/controllers/Search.php
@@ -253,9 +253,7 @@ class Search extends Instance_Controller {
 		$this->doctrine->em->flush();
 		$this->searchId = $searchArchive->getId();
 
-		$shouldReturnJson = strpos($this->input->get_request_header('Accept', true), 'application/json') !== false;
-
-		if ($this->isUsingVueUI() && $shouldReturnJson) {
+		if ($this->isUsingVueUI()) {
 			return $this->output
 			->set_content_type('application/json')
 			->set_output(json_encode(["searchId" => $this->searchId]));
@@ -294,9 +292,7 @@ class Search extends Instance_Controller {
 		$this->doctrine->em->flush();
 		$this->searchId = $searchArchive->getId();
 
-		$shouldReturnJson = strpos($this->input->get_request_header('Accept', true), 'application/json') !== false;
-
-		if ($this->isUsingVueUI() && $shouldReturnJson) {
+		if ($this->isUsingVueUI()) {
 			return $this->output
 			->set_content_type('application/json')
 			->set_output(json_encode(["searchId" => $this->searchId]));


### PR DESCRIPTION
This complements a forthcoming fix for the `clickToSearch` functionality in elevator-ui. 

Instead of redirecting to the search UI, the searchID can be requested as json so that the frontend can handle the routing.

I'm not sure about checking for both `isUsingVueUI` and the final `shouldReturnJson` parameter. Maybe just one check is fine? Or maybe it's better to have both to avoid breaking legacy ui functionality?