### PR TITLE
Add json return type param to delete/add drawers controllers

### DIFF
--- a/application/controllers/Drawers.php
+++ b/application/controllers/Drawers.php
@@ -288,7 +288,7 @@ class Drawers extends Instance_Controller {
 	}
 
 
-	public function delete($drawerId) {
+	public function delete($drawerId, $shouldReturnJson = false) {
 		$drawer = $this->doctrine->em->find("Entity\Drawer",$drawerId);
 		if(!$drawer) {
 			return render_json(["error"=>"fail", "status"=>500]);
@@ -301,9 +301,10 @@ class Drawers extends Instance_Controller {
 
 		$this->doctrine->em->remove($drawer);
 		$this->doctrine->em->flush();
-		instance_redirect("/");
 
-
+		return $shouldReturnJson 
+			? render_json([ "success" => true])
+			: instance_redirect("/");
 	}
 	public function addDrawer() {
 		$accessLevel = $this->user_model->getAccessLevel("instance", $this->instance);

--- a/application/controllers/Drawers.php
+++ b/application/controllers/Drawers.php
@@ -291,12 +291,14 @@ class Drawers extends Instance_Controller {
 	public function delete($drawerId, $shouldReturnJson = false) {
 		$drawer = $this->doctrine->em->find("Entity\Drawer",$drawerId);
 		if(!$drawer) {
-			return render_json(["error"=>"fail", "status"=>500]);
+			return render_json(["error" => "Not found", "status" => 404], 404);
 		}
-		$accessLevel = $this->user_model->getAccessLevel("drawer", $drawer);
 
-		if($accessLevel < PERM_CREATEDRAWERS) {
-			$this->errorhandler_helper->callError("noPermission");
+		$accessLevel = $this->user_model->getAccessLevel("drawer", $drawer);
+		if ($accessLevel < PERM_CREATEDRAWERS) {
+			return $shouldReturnJson 
+				? render_json(["error" => "No permission", "status" => 403], 403)
+				: $this->errorhandler_helper->callError("noPermission");
 		}
 
 		$this->doctrine->em->remove($drawer);

--- a/application/controllers/Drawers.php
+++ b/application/controllers/Drawers.php
@@ -288,7 +288,7 @@ class Drawers extends Instance_Controller {
 	}
 
 
-	public function delete($drawerId, $shouldReturnJson = false) {
+	public function delete($drawerId, $shouldReturnJSON = false) {
 		$drawer = $this->doctrine->em->find("Entity\Drawer",$drawerId);
 		if(!$drawer) {
 			return render_json(["error" => "Not found", "status" => 404], 404);
@@ -296,7 +296,7 @@ class Drawers extends Instance_Controller {
 
 		$accessLevel = $this->user_model->getAccessLevel("drawer", $drawer);
 		if ($accessLevel < PERM_CREATEDRAWERS) {
-			return $shouldReturnJson 
+			return $shouldReturnJSON 
 				? render_json(["error" => "No permission", "status" => 403], 403)
 				: $this->errorhandler_helper->callError("noPermission");
 		}
@@ -304,18 +304,18 @@ class Drawers extends Instance_Controller {
 		$this->doctrine->em->remove($drawer);
 		$this->doctrine->em->flush();
 
-		return $shouldReturnJson 
+		return $shouldReturnJSON
 			? render_json([ "success" => true])
 			: instance_redirect("/");
 	}
 
-	public function addDrawer($shouldReturnJson = false) {
+	public function addDrawer($shouldReturnJSON = false) {
 		$accessLevel = $this->user_model->getAccessLevel("instance", $this->instance);
 
 		$accessLevel = max($accessLevel, $this->user_model->getMaxCollectionPermission());
 
 		if($accessLevel < PERM_CREATEDRAWERS) {
-			return $shouldReturnJson 
+			return $shouldReturnJSON 
 				? render_json(["error" => "No permission", "status" => 403], 403)
 				: $this->errorhandler_helper->callError("noPermission");
 		}

--- a/application/controllers/Drawers.php
+++ b/application/controllers/Drawers.php
@@ -308,13 +308,16 @@ class Drawers extends Instance_Controller {
 			? render_json([ "success" => true])
 			: instance_redirect("/");
 	}
-	public function addDrawer() {
+
+	public function addDrawer($shouldReturnJson = false) {
 		$accessLevel = $this->user_model->getAccessLevel("instance", $this->instance);
 
 		$accessLevel = max($accessLevel, $this->user_model->getMaxCollectionPermission());
 
 		if($accessLevel < PERM_CREATEDRAWERS) {
-			$this->errorhandler_helper->callError("noPermission");
+			return $shouldReturnJson 
+				? render_json(["error" => "No permission", "status" => 403], 403)
+				: $this->errorhandler_helper->callError("noPermission");
 		}
 
 		$drawer = new Entity\Drawer;


### PR DESCRIPTION
This complements a forthcoming PR for adding/removing drawers in elevator-ui. It adds a `$shouldReturnJSON` param to the `delete` and `addDrawer` drawers controllers.

If successful, elevator will return a JSON success message rather than redirect to home.
If unsuccessful, elevator will return a error and status (`404` when trying to delete a folder that's not found, and `403` if the user is not permitted) rather than redirecting to an error page.