### PR TITLE
Add current sort state to `getDrawers`, `setSortOrder` json responses

### DIFF
--- a/application/controllers/Drawers.php
+++ b/application/controllers/Drawers.php
@@ -406,33 +406,25 @@ class Drawers extends Instance_Controller {
 
 	}
 
-	public function setSortOrder($drawerId, $sortOrder, $returnJSON = false) {
+	public function setSortOrder($drawerId, $sortOrder) {
 		if (!$drawerId) {
-			return $returnJSON 
-				? render_json(["error" => "Not found", "status" => 404], 404)
-				: show_404();
+			return render_json(["error" => "Not found", "status" => 404], 404);
 		}
 
 		if (!in_array($sortOrder, ['title.raw', 'custom'])) {
-			return $returnJSON 
-				? render_json(["error" => "Invalid sort order", "status" => 400], 400)
-				: show_error("Invalid sort order", 400);
+			return render_json(["error" => "Invalid sort order", "status" => 400], 400);
 		}
 
 		$drawer = $this->doctrine->em->find("Entity\Drawer", $drawerId);
 
 		if (!$drawer) {
-			return $returnJSON 
-				? render_json(["error" => "Not found", "status" => 404], 404)
-				: show_404();
+			return render_json(["error" => "Not found", "status" => 404], 404);
 		}
 
 		$accessLevel = $this->user_model->getAccessLevel("drawer", $drawer);
 
-		if($accessLevel < PERM_CREATEDRAWERS) {
-			return $returnJSON 
-				? render_json(["error" => "No permission", "status" => 403], 403)
-				: $this->errorhandler_helper->callError("noPermission");
+		if ($accessLevel < PERM_CREATEDRAWERS) {
+			return render_json(["error" => "No permission", "status" => 403], 403);
 		}
 
 		$drawer->setSortBy($sortOrder);

--- a/application/controllers/Drawers.php
+++ b/application/controllers/Drawers.php
@@ -166,6 +166,7 @@ class Drawers extends Instance_Controller {
 			$resultArray["totalResults"] = count($outputArray);
 			$resultArray["drawerId"] = $drawerId;
 			$resultArray["drawerTitle"] = $drawer->getTitle();
+			$resultArray['sortBy'] = $drawer->getSortBy();
 
 			return render_json($resultArray);
 		}


### PR DESCRIPTION
Sort state for drawers is persisted. This adds the current sort state for a given drawer to the api response, so that the frontend can properly set the sort option.

Also, `setSortOrder` is updated for JSON: requests are validated, and JSON errors are return for invalid requests.