### PR TITLE
add configurable `defaultTextTruncationHeight`

### DIFF
--- a/application/controllers/Instances.php
+++ b/application/controllers/Instances.php
@@ -79,6 +79,7 @@ class Instances extends Instance_Controller {
 		$instance->setDefaultTheme($this->input->post('defaultTheme'));
 		$instance->setAvailableThemes($this->input->post('availableThemes'));
 		$instance->setMaximumMoreLikeThis($this->input->post('maximumMoreLikeThis'));
+		$instance->setDefaultTextTruncationHeight($this->input->post('defaultTextTruncationHeight'));
 		$config['upload_path'] = '/tmp/';
 		$config['max_size']	= '0';
 		$config['allowed_types'] = 'png';

--- a/application/doctrine/Entity.Instance.dcm.xml
+++ b/application/doctrine/Entity.Instance.dcm.xml
@@ -108,7 +108,12 @@
                 <option name="default">3</option>
               </options>
           </field>
-          
+          <field name="defaultTextTruncationHeight" type="integer" nullable='true'>
+          <options>
+                <!-- 16px * 1.5 line-height * 3 lines = 72-->
+                <option name="default">72</option>
+              </options>
+          </field>
           <field name="availableThemes" type="json_array" nullable="true">
             <options>
               <option name="jsonb">true</option>

--- a/application/models/Entity/Instance.php
+++ b/application/models/Entity/Instance.php
@@ -1473,6 +1473,12 @@ class Instance
      */
     private $maximumMoreLikeThis = '3';
 
+    /**
+     * height of collapsed text area widget in pixels
+     * @var int|null
+     */
+    private $defaultTextTruncationHeight = 72;
+
 
 
     /**
@@ -1545,6 +1551,29 @@ class Instance
     public function getMaximumMoreLikeThis()
     {
         return $this->maximumMoreLikeThis;
+    }
+
+    /**
+     * Set defaultTextTruncationHeight.
+     * 
+     * @param int|null $defaultTextTruncationHeight
+     * 
+     * @return Instance
+     */
+    public function setDefaultTextTruncationHeight($defaultTextTruncationHeight = null) {
+        $this->defaultTextTruncationHeight = $defaultTextTruncationHeight;
+
+        return $this;
+    }
+
+
+    /**
+     * Get the height of the collapsed text area widget in pixels.
+     * 
+     * @return int|null
+     */
+    public function getDefaultTextTruncationHeight() {
+        return $this->defaultTextTruncationHeight;
     }
 
     /**

--- a/application/views/instances/_form_fields.php
+++ b/application/views/instances/_form_fields.php
@@ -347,6 +347,15 @@
 		<input type="text" name="maximumMoreLikeThis" id="maximumMoreLikeThis" class="form-control" value="<?= $instance->getMaximumMoreLikeThis(); ?>">
 	</div>
 </div>
+
+<div class="form-group">
+	<label for="defaultTextTruncationHeight" class="col-sm-2 control-label">
+		Text Area Widget Collapsed Height (px):
+	</label>
+	<div class="col-sm-6">
+		<input type="text" name="defaultTextTruncationHeight" id="defaultTextTruncationHeight" class="form-control" value="<?= $instance->getDefaultTextTruncationHeight(); ?>">
+	</div>
+</div>
 </fieldset>
 
 <div class="form-group">

--- a/application/views/vueTemplate.php
+++ b/application/views/vueTemplate.php
@@ -47,16 +47,21 @@ $cssFile = $manifest['src/main.css']['file'];
           },
           theming: {
             availableThemes: <?= json_encode($this->instance->getAvailableThemes()) ?>,
-            enabled: <?= $this->instance->getEnableThemes()?"true":"false" ?>,
+            enabled: <?= $this->instance->getEnableThemes() ? "true" : "false" ?>,
             defaultTheme: "<?= $this->instance->getDefaultTheme() ?>",
+          },
+          moreLikeThis: {
+            maxInlineResults: <?= $this->instance->getMaximumMoreLikeThis() ?>,
+          },
+          textAreaItem: {
+            defaultTextTruncationHeight: <?=
+              $this->instance->getDefaultTextTruncationHeight() 
+            ?>,
           },
         },
         arcgis: {
           apiKey: "<?= $this->config->item('arcgis_access_token') ?>",
         },
-        moreLikeThis: {
-          maxInlineResults: <?= $this->instance->getMaximumMoreLikeThis() ?>,
-        }
       },
     }
   </script>


### PR DESCRIPTION
This adds the ability for instance admins to configure the height of the collapsed textareawidget.

A new column `defaultTextTruncationHeight` is added to the instance table in `Entity.Instance.dcm.xml` to hold this value.