### PR TITLE
include custom css in vue template

### DIFF
--- a/application/views/vueTemplate.php
+++ b/application/views/vueTemplate.php
@@ -12,6 +12,9 @@ if (json_last_error() !== JSON_ERROR_NONE) {
 
 $indexFile = $manifest['src/main.ts']['file'];
 $cssFile = $manifest['src/main.css']['file'];
+
+$customCSSFile = "/assets/instanceAssets/{$this->instance->getId()}.css";
+$customCSSHash = $this->instance->getModifiedAt()->getTimestamp();
 ?>
 
 <!DOCTYPE html>
@@ -67,6 +70,9 @@ $cssFile = $manifest['src/main.css']['file'];
   </script>
 
   <link rel="stylesheet" href="/assets/elevator-ui/dist/<?= $cssFile ?>">
+  <?php if (isset($this->instance) && $this->instance->getUseCustomCSS()): ?>
+    <link rel="stylesheet" href="<?= $customCSSFile ?>?hash=<?= $customCSSHash ?>">
+  <?php endif ?>
   <script type="module" crossorigin src="/assets/elevator-ui/dist/<?= $indexFile ?>"></script>
 </head>
 


### PR DESCRIPTION
This lets admins include customCSS. The `modifiedAt` timestamp for instance settings is used as a hash. I went this route since:
- it should change when any customCSS is changed, so it should cache-bust appropriately.
- it is pretty stable, since settings aren't modified often. Thus it should reduce requests for css.
- it doesn't require adding additional info to the db
- it's already in memory, so doesn't need to be computed on the fly (like an md5 or last modified date of the css file)

There may be better choices though.