### PR TITLE
Make home page configurable in vue ui

### DIFF
--- a/application/controllers/Instances.php
+++ b/application/controllers/Instances.php
@@ -78,6 +78,7 @@ class Instances extends Instance_Controller {
 		$instance->setEnableThemes($this->input->post('enableTheming'));
 		$instance->setDefaultTheme($this->input->post('defaultTheme'));
 		$instance->setAvailableThemes($this->input->post('availableThemes'));
+		$instance->setCustomHomeRedirect($this->input->post('customHomeRedirect'));
 		$instance->setMaximumMoreLikeThis($this->input->post('maximumMoreLikeThis'));
 		$instance->setDefaultTextTruncationHeight($this->input->post('defaultTextTruncationHeight'));
 		$config['upload_path'] = '/tmp/';

--- a/application/doctrine/Entity.Instance.dcm.xml
+++ b/application/doctrine/Entity.Instance.dcm.xml
@@ -103,6 +103,7 @@
                 <option name="default">0</option>
               </options>
           </field>
+          <field name="customHomeRedirect" type="string" nullable='true' />
           <field name="maximumMoreLikeThis" type="integer" nullable='true'>
           <options>
                 <option name="default">3</option>

--- a/application/models/Entity/Instance.php
+++ b/application/models/Entity/Instance.php
@@ -1605,4 +1605,32 @@ class Instance
     {
         return $this->availableThemes;
     }
+    /**
+     * @var string|null
+     */
+    private $customHomeRedirect;
+
+
+    /**
+     * Set customHomeRedirect.
+     *
+     * @param string|null $customHomeRedirect
+     *
+     * @return Instance
+     */
+    public function setCustomHomeRedirect($customHomeRedirect = null)
+    {
+        $this->customHomeRedirect = $customHomeRedirect;
+        return $this;
+    }
+
+    /**
+     * Get customHomeRedirect.
+     *
+     * @return string|null
+     */
+    public function getCustomHomeRedirect()
+    {
+        return $this->customHomeRedirect;
+    }
 }

--- a/application/views/instances/_form_fields.php
+++ b/application/views/instances/_form_fields.php
@@ -341,6 +341,16 @@
 		
 	</div>
 </div>
+
+<div class="form-group">
+	<label for="customHomeRedirect" class="col-sm-2 control-label">
+		Custom Home Redirect:
+	</label>
+	<div class="col-sm-6">
+		<input type="text" name="customHomeRedirect" id="customHomeRedirect" class="form-control" value="<?= $instance->getCustomHomeRedirect(); ?>">
+	</div>
+</div>
+
 <div class="form-group">
 	<label for="maximumMoreLikeThis" class="col-sm-2 control-label">More Like This Display Count:</label>
 	<div class="col-sm-6">

--- a/application/views/vueTemplate.php
+++ b/application/views/vueTemplate.php
@@ -41,6 +41,11 @@ function makeJavaScriptConfig($instance, $config, $template) {
       'arcgis' => [
           'apiKey' => $config->item('arcgis_access_token'),
       ],
+      'routes' => [
+        'home' => [
+          'redirect' => $instance->getCustomHomeRedirect() ?? null,
+        ]
+      ]
   ];
 
   return json_encode($jsConfig, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_SLASHES);


### PR DESCRIPTION
This complements https://github.com/UMN-LATIS/elevator-ui/pull/260, allowing admins to set a custom home page.

A new `customHomeRedirect` property is set on the `instance` model. This value will be included in the JS config passed vue via the vue template.

As part of this, the vue template config creation logic is pulled out into a separate `makeJavaScriptConfig` helper method on the template to create the config as a php associative array and then convert to JSON. Previously, a bunch of php echos in the JS script tag were used, which was difficult to read (and seemed to confuse the intelliphense VS code plugin).
