### PR TITLE
add privilege information to collections

### DIFF
--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -287,6 +287,7 @@ class Home extends Instance_Controller {
 				$collectionEntry = [];
 				$collectionEntry["id"] = $collection->getId();
 				$collectionEntry["title"] = $collection->getTitle();
+				$collectionEntry["canEdit"] = false;
 				$collectionEntry["previewImageId"] = 
 				$collection->getPreviewImage();
 

--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -278,10 +278,7 @@ class Home extends Instance_Controller {
 		// with their view/edit status
 		$canEditSomeCollection = count($editableCollectionIds) > 0;
 		foreach ($rootCollections as $collection) {
-			$isBrowseable = $collection->getShowInBrowse();
-
-			// can a collection be browseable but not viewable?
-			$canView = $isBrowseable || in_array($collection->getId(), $viewableCollectionIds);
+			$canView = in_array($collection->getId(), $viewableCollectionIds);
 			$canEdit = in_array($collection->getId(), $editableCollectionIds);
 			
 			// if the user can view this collection or
@@ -293,6 +290,7 @@ class Home extends Instance_Controller {
 			$collectionEntry = [
 				'id' => $collection->getId(),
 				'title' => $collection->getTitle(),
+				'showInBrowse' => $collection->getShowInBrowse(),
 				'canView' => $canView,
 				'canEdit' => $canEdit,
 				'previewImageId' => $collection->getPreviewImage()


### PR DESCRIPTION
Augments the `getInstanceNav` api endpoint. 

Builds on #179, consolidating `collections` and `editableCollections` by adding `canEdit` and `canView` permission info directly to the collections.
