### PR TITLE
fix: view permissions for collections

### DIFF
--- a/application/controllers/Home.php
+++ b/application/controllers/Home.php
@@ -238,7 +238,7 @@ class Home extends Instance_Controller {
 		$headerData["showPreviousNext"] = $this->instance->getShowPreviousNextSearchResults();
 
 		$rootCollections = $this->instance->getCollectionsWithoutParent();
-		$viewableCollectionIds = array_map(fn($c) => $c->getId(), $this->collection_model->getUserCollections());
+		$viewableCollectionIds = array_map(fn($c) => $c->getId(), $this->user_model->getAllowedCollections(PERM_SEARCH));
 		$editableCollectionIds = array_map(fn($c) => $c->getId(), $this->user_model->getAllowedCollections(PERM_ADDASSETS));
 
 		// nest and add `canView` and `canEdit` props to collections


### PR DESCRIPTION
Fixes an issue where child collections wouldn't show up on the all collections page. 

The child collections would have were missing view permissions, because we weren't recursively checking child collections. This fixes the issue by using `$user->getAllowedCollections()` which returns a flat collection list.

On dev.