### PR TITLE
fix(asset): return JSON 404 for missing assets

### DIFF
--- a/application/controllers/Asset.php
+++ b/application/controllers/Asset.php
@@ -39,11 +39,15 @@ class asset extends Instance_Controller {
 
 
 		if(!$assetModel->loadAssetById($objectId, $noHydrate = true)) {
-			show_404();
+			return $isJson
+				? render_json(["error" => "not found"], 404)
+				: show_404();
 		}
 
 		if(!$this->collection_model->getCollection($assetModel->assetObject->getCollectionId())) {
-			show_404();
+			return $isJson
+				? render_json(["error" => "not found"], 404)
+				: show_404();
 		}
 		$this->accessLevel = $this->user_model->getAccessLevel("asset", $assetModel);
 

--- a/tests/api/assets.spec.ts
+++ b/tests/api/assets.spec.ts
@@ -9,6 +9,32 @@ import {
   createUser,
 } from "../helpers";
 
+test.describe("getAsset missing asset", () => {
+  test.beforeEach(() => {
+    refreshDatabase();
+  });
+
+  test("returns JSON 404 when JSON is requested", async ({ request }) => {
+    const res = await request.get(
+      `${baseURL()}/asset/getAsset/000000000000000000000000`,
+      { headers: { Accept: "application/json" } },
+    );
+
+    expect(res.status()).toBe(404);
+    expect(res.headers()["content-type"]).toContain("application/json");
+    expect(await res.json()).toEqual({ error: "not found" });
+  });
+
+  test("keeps the legacy HTML 404 response", async ({ request }) => {
+    const res = await request.get(
+      `${baseURL()}/asset/getAsset/000000000000000000000000`,
+    );
+
+    expect(res.status()).toBe(404);
+    expect(res.headers()["content-type"]).toContain("text/html");
+  });
+});
+
 test.describe("assets", () => {
   test.beforeAll(() => {
     refreshDatabase();


### PR DESCRIPTION
## Summary

- return a JSON 404 response when `Asset::getAsset()` cannot load an asset or its collection
- preserve the legacy HTML 404 response when JSON is not requested
- add endpoint regression tests for JSON content negotiation and legacy behavior

## Testing

- `npm test` — 204 passed, 5 skipped
- `npx tsc --noEmit`
- `php -l application/controllers/Asset.php`

Addresses the `Asset::getAsset()` portion of #217.